### PR TITLE
Expose four required properties via getter methods

### DIFF
--- a/core/src/main/java/au/com/objectix/jgridshift/GridShiftFile.java
+++ b/core/src/main/java/au/com/objectix/jgridshift/GridShiftFile.java
@@ -346,7 +346,35 @@ public class GridShiftFile implements Serializable {
         }
         return sub;
     }
-    
+
+    /**
+    * @return the semi major axis of the from ellipsoid
+    */
+    public double getFromSemiMajorAxis() {
+        return fromSemiMajorAxis;
+    }
+
+    /**
+     * @return the semi minor axis of the from ellipsoid
+     */
+    public double getFromSemiMinorAxis() {
+        return fromSemiMinorAxis;
+    }
+
+    /**
+     * @return the semi major axis of the to ellipsoid
+     */
+    public double getToSemiMajorAxis() {
+        return toSemiMajorAxis;
+    }
+
+    /**
+     * @return the semi minor axis of the to ellipsoid
+     */
+    public double getToSemiMinorAxis() {
+        return toSemiMinorAxis;
+    }
+
     public boolean isLoaded() {
         return (topLevelSubGrid != null);
     }


### PR DESCRIPTION
With this PR we would like to contribute a simple patch which exposes four properties via getter methods. Within the OSGeo project deegree we use an old and outdated fork of jgridshift with this tiny little change. And our goal is to get rid of this patched and unmaintained version and use the releases provided here instead.

Furthermore, the repository operated by the OSGeo project deegree serves such unmaintained and patched versions of libraries missing licences. To align the usage of third-party libraries within the deegree project we highly appreciate if you can merge this PR and provide a release version including this PR.

If we can support during merge and release process please let us know. We are willing to support.