### PR TITLE
bump junit to 4.13.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR upgrades JUnit to v.4.13.2 which contains fix for [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp).